### PR TITLE
use gf sdk server replace cmd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+/components/
+.idea

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "components/gf-sdk-server"]
+	path = components/gf-sdk-server
+	url = https://github.com/Novo-Network/gf-sdk-server

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,12 @@ celestia-rpc = { git = "https://github.com/eigerco/celestia-node-rs.git", option
 celestia-types = { git = "https://github.com/eigerco/celestia-node-rs.git", optional = true }
 reqwest = { version = "0.11.23", features = ["json", "stream"], optional = true }
 serde_json = { version = "1.0.105", optional = true }
+tokio = { version = "1.35.0", features = ["full"], optional = true }
 
 [features]
 default = ["file", "ipfs", "celestia", "greenfield", "ethereum"]
 file = ["sha3", "hex"]
 ipfs = ["ipfs-api-backend-hyper", "ipfs-api", "base58", "futures" ]
 celestia = ["celestia-rpc", "celestia-types", "hex"]
-greenfield = ["sha3", "hex", "serde_json", "reqwest"]
+greenfield = ["sha3", "hex", "serde_json", "reqwest", "tokio"]
 ethereum = ["ethers", "hex"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "da"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -22,11 +23,13 @@ ipfs-api = { version = "0.17.0", features = ["with-hyper-rustls"], default-featu
 
 celestia-rpc = { git = "https://github.com/eigerco/celestia-node-rs.git", optional = true }
 celestia-types = { git = "https://github.com/eigerco/celestia-node-rs.git", optional = true }
+reqwest = { version = "0.11.23", features = ["json", "stream"], optional = true }
+serde_json = { version = "1.0.105", optional = true }
 
 [features]
 default = ["file", "ipfs", "celestia", "greenfield", "ethereum"]
 file = ["sha3", "hex"]
 ipfs = ["ipfs-api-backend-hyper", "ipfs-api", "base58", "futures" ]
 celestia = ["celestia-rpc", "celestia-types", "hex"]
-greenfield = ["sha3", "hex"]
+greenfield = ["sha3", "hex", "serde_json", "reqwest"]
 ethereum = ["ethers", "hex"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,18 @@
+use std::process::Command;
+
+fn main() {
+    if cfg!(feature = "greenfield") {
+        // download gf server
+        Command::new("git")
+            .args(["submodule", "update", "--init", "--remote"])
+            .status()
+            .expect("Failed to initialize and update submodule");
+
+        // build
+        Command::new("make")
+            .args(["build"])
+            .current_dir("components/gf-sdk-server")
+            .status()
+            .expect("Failed to execute make in the submodule");
+    }
+}

--- a/src/celestia_service.rs
+++ b/src/celestia_service.rs
@@ -1,7 +1,8 @@
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use celestia_rpc::{BlobClient, Client};
-use celestia_types::{blob::SubmitOptions, consts::HASH_SIZE, nmt::Namespace, Blob, Commitment};
+use celestia_types::blob::GasPrice;
+use celestia_types::{consts::HASH_SIZE, nmt::Namespace, Blob, Commitment};
 use serde::{Deserialize, Serialize};
 
 use crate::{service::DAService, DaType};
@@ -38,10 +39,13 @@ impl DAService for CelestiaService {
     }
 
     async fn set_full_tx(&self, tx: &[u8]) -> Result<Vec<u8>> {
-        let opts = SubmitOptions::default();
+        // let opts = SubmitOptions::default();
         let blob = Blob::new(self.namespace, tx.to_vec())?;
         let mut hash = blob.commitment.0.to_vec();
-        let height = self.client.blob_submit(&[blob], opts).await?;
+        let height = self
+            .client
+            .blob_submit(&[blob], GasPrice::from(None))
+            .await?;
         hash.extend_from_slice(&height.to_be_bytes());
         Ok(hash)
     }

--- a/src/greenfield_servic.rs
+++ b/src/greenfield_servic.rs
@@ -1,25 +1,27 @@
-use std::{fs, process::Command};
-
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 
-use crate::{service::DAService, DaType};
+use crate::greenfield_servic::gf_sdk_server::{create_obj, get_obj, put_obj, Req};
+use crate::{DAService, DaType};
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Config {
     pub rpc_addr: String,
     pub chain_id: String,
     pub bucket: String,
-    pub password_file: String,
+    pub private_key_path: String,
+    pub gf_sdk_host: String,
 }
 
+#[allow(dead_code)]
 pub struct GreenfieldService {
     rpc_addr: String,
     chain_id: String,
     bucket: String,
-    password_file: String,
+    private_key_path: String,
+    gf_sdk_host: String,
 }
 
 impl GreenfieldService {
@@ -28,7 +30,8 @@ impl GreenfieldService {
             rpc_addr: cfg.rpc_addr,
             chain_id: cfg.chain_id,
             bucket: cfg.bucket,
-            password_file: cfg.password_file,
+            private_key_path: cfg.private_key_path,
+            gf_sdk_host: cfg.gf_sdk_host,
         }
     }
 
@@ -39,83 +42,132 @@ impl GreenfieldService {
 
 #[async_trait]
 impl DAService for GreenfieldService {
-    async fn hash(&self, tx: &[u8]) -> Result<Vec<u8>> {
-        Ok(Keccak256::digest(tx).to_vec())
-    }
-
     async fn set_full_tx(&self, tx: &[u8]) -> Result<Vec<u8>> {
-        let hash = self.hash(tx).await?;
-        if let Ok(content) = self.get_tx(&hash).await {
-            if !content.is_empty() {
-                return Ok(hash);
+        // judge
+        let hash = {
+            let hash = self.hash(tx).await?;
+            if let Ok(content) = self.get_tx(&hash).await {
+                if !content.is_empty() {
+                    return Ok(hash);
+                }
+            }
+            hash
+        };
+
+        // gen url and req
+        let (req, url) = {
+            let obj = hex::encode(&hash);
+            let url = format!("{}/object/{}/{}", self.gf_sdk_host, self.bucket, obj);
+            let data = hex::encode(tx);
+            let req = Req {
+                data,
+                content_type: "text/plain".to_string(),
+                visibility: "private".to_string(),
+                sync: true,
+            };
+            (req, url)
+        };
+
+        // create obj
+        {
+            let resp = create_obj(&req, &url).await?;
+            println!("{:?}", resp);
+
+            if resp.code != 0 {
+                return Err(anyhow::Error::msg(format!(
+                    "create obj fail: {}, id:[{}]",
+                    resp.msg, resp.id
+                )));
             }
         }
-        let key = hex::encode(&hash);
-        let _ = fs::remove_file(format!("/tmp/.{}.tmp", key));
-        let value = hex::encode(tx);
-        let file_name = format!("/tmp/{}", key);
-        fs::write(&file_name, value)?;
 
-        //gnfd-cmd --rpcAddr "https://gnfd-testnet-fullnode-tendermint-us.bnbchain.org:443" --chainId "greenfield_5600-1" object put   --visibility private ./test1.txt  gnfd://bucket123123123/test1.txt
-        let mut cmd = Command::new("gnfd-cmd");
-        cmd.arg("--rpcAddr")
-            .arg(&self.rpc_addr)
-            .arg("--chainId")
-            .arg(&self.chain_id)
-            .arg("--passwordfile")
-            .arg(&self.password_file)
-            .arg("object")
-            .arg("put")
-            .arg("--contentType")
-            .arg("'text/plain'")
-            .arg("--visibility")
-            .arg("private")
-            .arg(&file_name)
-            .arg(format!("gnfd://{}/{}", self.bucket, key));
-        let output = cmd.output()?;
-        let show = String::from_utf8(output.stdout)?;
-        if !output.status.success() {
-            return Err(anyhow!(show));
+        // put obj
+        {
+            let resp = put_obj(&req, &url).await?;
+            println!("{:?}", resp);
+
+            if resp.code != 0 {
+                return Err(anyhow::Error::msg(format!(
+                    "put obj fail: {}, id:[{}]",
+                    resp.msg, resp.id
+                )));
+            }
         }
-        println!("{}", show);
-        let _ = fs::remove_file(file_name);
+
         Ok(hash)
     }
 
     async fn get_tx(&self, hash: &[u8]) -> Result<Vec<u8>> {
-        let key = hex::encode(hash);
-        let _ = fs::remove_file(format!("/tmp/.{}.tmp", key));
-        println!("get tx");
-        let file_name = format!("/tmp/{}", key);
+        let obj = hex::encode(hash);
 
-        //gnfd-cmd --rpcAddr "https://gnfd-testnet-fullnode-tendermint-us.bnbchain.org:443" --chainId "greenfield_5600-1" object get gnfd://bucket123123123/test1.txt ./test-copy.txt
-        let mut cmd = Command::new("gnfd-cmd");
-        cmd.arg("--rpcAddr")
-            .arg(&self.rpc_addr)
-            .arg("--chainId")
-            .arg(&self.chain_id)
-            .arg("--passwordfile")
-            .arg(&self.password_file)
-            .arg("object")
-            .arg("get")
-            .arg(format!("gnfd://{}/{}", self.bucket, key))
-            .arg(file_name.clone());
-        let output = cmd.output()?;
-        let show = String::from_utf8(output.stdout)?;
-        println!("{}", show);
-        if !output.status.success() {
-            return Err(anyhow!(show));
-        }
+        // gen url
+        let url = format!("{}/object/{}/{}", self.gf_sdk_host, self.bucket, obj);
 
-        let file_content = fs::read_to_string(&file_name)?;
-        let content = hex::decode(file_content)?;
+        let resp = get_obj(&url).await?;
 
-        let _ = fs::remove_file(file_name);
-        let _ = fs::remove_file(format!("/tmp/.{}.tmp", key));
-        Ok(content)
+        Ok(resp)
     }
 
     fn type_byte(&self) -> u8 {
         DaType::Greenfield.type_byte()
+    }
+
+    async fn hash(&self, tx: &[u8]) -> Result<Vec<u8>> {
+        Ok(Keccak256::digest(tx).to_vec())
+    }
+}
+
+mod gf_sdk_server {
+    use anyhow::Result;
+    use futures::StreamExt;
+    use reqwest::{Body, Client, Url};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct Req {
+        pub data: String,
+        pub content_type: String,
+        pub visibility: String,
+        pub sync: bool,
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct Resp {
+        pub data: String,
+        pub msg: String,
+        pub code: i32,
+        pub id: String,
+    }
+
+    pub async fn create_obj(req: &Req, url: &str) -> Result<Resp> {
+        let cli = Client::new();
+        let r = cli
+            .post(Url::parse(url)?)
+            .body(Body::from(serde_json::to_vec(req)?))
+            .build()?;
+        let resp = cli.execute(r).await?.json::<Resp>().await?;
+        Ok(resp)
+    }
+
+    pub async fn put_obj(req: &Req, url: &str) -> Result<Resp> {
+        let cli = Client::new();
+        let r = cli
+            .put(Url::parse(url)?)
+            .body(Body::from(serde_json::to_vec(req)?))
+            .build()?;
+        let resp = cli.execute(r).await?.json::<Resp>().await?;
+        Ok(resp)
+    }
+
+    pub async fn get_obj(url: &str) -> Result<Vec<u8>> {
+        let resp = reqwest::get(Url::parse(url)?).await?;
+        let mut stream = resp.bytes_stream();
+        let mut data = vec![];
+
+        while let Some(chunk) = stream.next().await {
+            data.extend_from_slice(&chunk?);
+        }
+
+        Ok(data)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(warnings, unused_crate_dependencies)]
-
+use tokio as _;
 mod da_type;
 pub use da_type::*;
 


### PR DESCRIPTION
When the feature `features=greenfield` is enabled, the build script (build.rs) updates the submodule, pulls the code for gf-sdk-server, and then uses `make build` to compile the binary file. 
Then, `gf-sdk-server` is launched at the time of `DAServiceManager::new()`. However, in the test cases that simulate this process, it would be better to change the construction data, because that data has already been submitted.